### PR TITLE
remove duplicated link to "whats new" page

### DIFF
--- a/views/main_layout.haml
+++ b/views/main_layout.haml
@@ -20,7 +20,6 @@
       %a.mdl-navigation__link{href: '/'} ホーム
       %a.mdl-navigation__link{href: '/index_pages/index_top.html'} 作品一覧
       %a.mdl-navigation__link{href: '/index_pages/whatsnew1.html'} 新着情報
-      %a.mdl-navigation__link{href: '/index_pages/whatsnew1.html'} 新着情報
       %a.mdl-navigation__link{href: 'http://www.aozora.gr.jp/guide/aozora_bunko_hayawakari.html'} 青空文庫早わかり
       %a.mdl-navigation__link{href: 'http://www.aozora.gr.jp/aozorablog/'} aozorablog
       %a.mdl-navigation__link{href: 'http://honnomirai.net/'} 本の未来基金


### PR DESCRIPTION
こちらは誤って2つ並んでしまった感じでしょうか
