### PR TITLE
use SSL on www.aozora.gr.jp

### DIFF
--- a/app/fetcher.rb
+++ b/app/fetcher.rb
@@ -4,7 +4,7 @@ module Aozora
 
     attr_reader :url
 
-    BASE_URI = 'http://www.aozora.gr.jp'
+    BASE_URI = 'https://www.aozora.gr.jp'
 
     def initialize(url)
       @url = "#{BASE_URI}/#{url}"

--- a/views/main_layout.haml
+++ b/views/main_layout.haml
@@ -20,8 +20,8 @@
       %a.mdl-navigation__link{href: '/'} ホーム
       %a.mdl-navigation__link{href: '/index_pages/index_top.html'} 作品一覧
       %a.mdl-navigation__link{href: '/index_pages/whatsnew1.html'} 新着情報
-      %a.mdl-navigation__link{href: 'http://www.aozora.gr.jp/guide/aozora_bunko_hayawakari.html'} 青空文庫早わかり
-      %a.mdl-navigation__link{href: 'http://www.aozora.gr.jp/aozorablog/'} aozorablog
+      %a.mdl-navigation__link{href: 'https://www.aozora.gr.jp/guide/aozora_bunko_hayawakari.html'} 青空文庫早わかり
+      %a.mdl-navigation__link{href: 'https://www.aozora.gr.jp/aozorablog/'} aozorablog
       %a.mdl-navigation__link{href: 'http://honnomirai.net/'} 本の未来基金
       %a.mdl-navigation__link{href: 'https://github.com/aozorahack'} aozorahack
 
@@ -36,9 +36,9 @@
         %h1.mdl-mega-footer__heading 資料室
         %ul.mdl-mega-footer__link-list
           %li
-            %a{href: 'http://www.aozora.gr.jp/aozora-manual/'} 青空文庫作業マニュアル
+            %a{href: 'https://www.aozora.gr.jp/aozora-manual/'} 青空文庫作業マニュアル
           %li
-            %a{href: 'http://www.aozora.gr.jp/annotation/'} 注記一覧
+            %a{href: 'https://www.aozora.gr.jp/annotation/'} 注記一覧
           %li
             %a{href: 'http://kumihan.aozora.gr.jp/'} 組版案内
             / TODO: 足す
@@ -47,10 +47,10 @@
         %h1.mdl-mega-footer__heading 運営について
         %ul.mdl-mega-footer__link-list
           %li
-            %a{href: 'http://www.aozora.gr.jp/cards/001790/card56572.html'} 青空文庫の提案
+            %a{href: 'https://www.aozora.gr.jp/cards/001790/card56572.html'} 青空文庫の提案
           %li
-            %a{href: 'http://www.aozora.gr.jp/aozora_bunkono_shikumi.html'} 青空文庫のしくみ
+            %a{href: 'https://www.aozora.gr.jp/aozora_bunkono_shikumi.html'} 青空文庫のしくみ
           %li
-            %a{href: 'http://www.aozora.gr.jp/kaikei/index.html'} 会計報告
+            %a{href: 'https://www.aozora.gr.jp/kaikei/index.html'} 会計報告
             / TODO: 足す
       / TODO: 足す


### PR DESCRIPTION
aozora_mobileを(aozora.gr.jpで)本格的に使おうという話が出ているそうなので、少し触っています。
とりあえずwww.aozora.gr.jpがSSL化したのに対応する修正です。