### PR TITLE
add Fetcher#proxy

### DIFF
--- a/app/fetcher.rb
+++ b/app/fetcher.rb
@@ -10,6 +10,15 @@ module Aozora
       @url = "#{BASE_URI}/#{url}"
     end
 
+    def proxy
+      content = content_type = nil
+      open(url) do |f|
+        content_type = f.content_type
+        content = f.read
+      end
+      return content, content_type
+    end
+
     def fetch(charset = nil)
       html = open(url) do |f|
         charset ||= f.charset

--- a/app/main.rb
+++ b/app/main.rb
@@ -4,6 +4,15 @@ require_relative 'book'
 require_relative 'card'
 require_relative 'page'
 
+helpers do
+  def proxy
+    fetcher = Aozora::Fetcher.new(request.path)
+    content, c_type = fetcher.proxy
+    content_type c_type
+    content
+  end
+end
+
 get '/' do
   index = Aozora::Index.new
 
@@ -61,6 +70,14 @@ end
 
 get '/css/book.css' do
   sass :'sass/book'
+end
+
+get '/*.ico' do
+  proxy
+end
+
+get '/images/*.png' do
+  proxy
 end
 
 get '/*' do


### PR DESCRIPTION
/images/*.pngや/favicon.icoにアクセスがあるとエラーが出ていたので、Aozora::Fetcherにproxyメソッドを追加して、この辺へのアクセスをそのままclientに返すようにしました。